### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@ vmaig.com 网站源码
 [![Travis](https://img.shields.io/travis/billvsme/vmaig_blog.svg)](https://travis-ci.org/billvsme/vmaig_blog)
 [![Docker Stars](https://img.shields.io/docker/stars/billvsme/vmaig_blog.svg)](https://hub.docker.com/r/billvsme/vmaig_blog/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/billvsme/vmaig_blog.svg)](https://hub.docker.com/r/billvsme/vmaig_blog/)
-#有问题欢迎加qq群
+# 有问题欢迎加qq群
 vmaig qq群: 458788510  
 我的qq: 994171686  
 
 [使用Docker部署vmaig_blog](http://vmaig.com/article/deplay_vmaig_blog.html)
 
-#更新日志
+# 更新日志
 2015/5/15 从django1.6 升级到 django1.8 (还保留django1.6分支)  
 2015/6/21 添加[xadmin分支](https://github.com/billvsme/vmaig_blog/tree/xadmin),xadmin分支中使用xadmin作为后台管理(使用 django 1.8),如果你想后台比较漂亮可以切换到xadmin分支(注意你不需要pip install django-xadmin 但是需要安装django-crispy-forms跟django-reversion详细步骤见xadmin分支中的README)  
 2015/7/5 对xadmin分支中的错误进行了比较大的修改  
 2016/3/17 添加评论回复  
 2016/3/22 添加Dockerfile，使用Docker部署本博客  
 
-#概述
+# 概述
 vmaig\_blog 是一个基于  **Django1.8**  跟  **Bootstrap3**  开发的 **博客系统** ，实现了一个博客完整的功能。https://vmaig.com 就是基于vmaig\_blog 搭建的。
-#功能
+# 功能
 1. 文章,分类,专栏的添加，删除，修改。支持**tinymce**富文本编辑器。支持文章中代码**高亮**。
 2. 实现**用户注册,登陆,修改密码,忘记重置密码**。通过**邮箱**通知注册用户, 用户忘记密码基于邮件（需要在setting.py设置好邮箱)。
 3. 实现**用户头像**，用户可以上传头像，然后编辑头像大小，然后保存，头像可以存在本地，也可自动保存在**七牛**云中（需要在setting.py 中设置好七牛的相关配置, 并修改相关代码）。
@@ -31,16 +31,16 @@ vmaig\_blog 是一个基于  **Django1.8**  跟  **Bootstrap3**  开发的 **博
 8. 拥有一个以**时间轴**显示的非常酷炫的“新闻”板块，你可以每天在后台添加新闻。
 9. 支持**手机浏览**，对手机浏览进行了调整。
 
-#Demo
+# Demo
 https://vmaig.com   
 
-#预览
+# 预览
 ![首页](http://vmaig.qiniudn.com/screenshot/vmaig_01.jpg)
 ![头像](http://vmaig.qiniudn.com/screenshot/vmaig_02.jpg)
 ![评论](http://vmaig.qiniudn.com/screenshot/vmaig_03.jpg)
 ![新闻](http://vmaig.qiniudn.com/screenshot/vmaig_news.jpg)
 
-#安装运行
+# 安装运行
 安装virtualenv :
 
     sudo pip install virtualenv
@@ -153,7 +153,7 @@ https://vmaig.com
 	
 运行后，默认管理员用户名为 admin，密码为 password ， 请登录 http://your-domain/admin 更改密码。                   
 
-#接下来该干什么？
+# 接下来该干什么？
 在浏览器中输入 http://127.0.0.1:8000/admin  
 输入前面初始化数据库时的用户名密码。  
 后台中，可以  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
